### PR TITLE
Attempting a quick workaround for gush creating a massive number of r…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ tmp
 test.rb
 /Gushfile
 dump.rdb
+.ruby-version
+.ruby-gemset


### PR DESCRIPTION
…edis connection.

With this design, each thread has its own redis connection (which is replaced if for some reason
a new redis url is seen (should be unlikely))