### PR TITLE
Set TTL on job key based on class not name (name includes uuid which …

### DIFF
--- a/lib/gush/client.rb
+++ b/lib/gush/client.rb
@@ -149,7 +149,7 @@ module Gush
 
     def expire_job(workflow_id, job, ttl=nil)
       ttl = ttl || configuration.ttl
-      redis.expire("gush.jobs.#{workflow_id}.#{job.name}", ttl)
+      redis.expire("gush.jobs.#{workflow_id}.#{job.klass}", ttl)
     end
 
     def enqueue_job(workflow_id, job)

--- a/spec/gush/client_spec.rb
+++ b/spec/gush/client_spec.rb
@@ -95,12 +95,18 @@ describe Gush::Client do
   end
 
   describe "#expire_workflow" do
+    let(:ttl) { 2000 }
+
     it "sets TTL for all Redis keys related to the workflow" do
       workflow = TestWorkflow.create
 
-      client.expire_workflow(workflow, -1)
+      client.expire_workflow(workflow, ttl)
 
-      # => TODO - I believe fakeredis does not handle TTL the same.   
+      expect(redis.ttl("gush.workflows.#{workflow.id}")).to eq(ttl)
+
+      workflow.jobs.each do |job|
+        expect(redis.ttl("gush.jobs.#{workflow.id}.#{job.klass}")).to eq(ttl)
+      end
     end
   end
 


### PR DESCRIPTION
…doesn't exist in redis). Added tests to verify as well.